### PR TITLE
Use session auth for Eval CLI

### DIFF
--- a/agent-evaluation/README.md
+++ b/agent-evaluation/README.md
@@ -25,7 +25,7 @@ You will be asked for:
 
 The CLI will:
 
-1. Generate an API key for the evaluation
+1. Start an anonymous evaluation session
 2. Create a temporary agent
 3. Run a small set of test prompts against your endpoint
 4. Show progress and a summary of passed/failed tests

--- a/agent-evaluation/src/App.tsx
+++ b/agent-evaluation/src/App.tsx
@@ -308,8 +308,8 @@ export const App: React.FC<AppProps> = ({
         try {
           const startTime = Date.now();
           
-          setPdfProgress('Generating API key...');
-          await api.generateApiKey('CLI Evaluation');
+          setPdfProgress('Starting evaluation session...');
+          await api.initializeEvaluationSession();
           
           setPdfProgress('Creating agent...');
           const agent = await api.createAgent(agentEndpoint);
@@ -356,7 +356,7 @@ export const App: React.FC<AppProps> = ({
           const logs: Array<{question: string, response: string}> = [];
           
           setEvaluationProgress(5);
-          await api.generateApiKey('CLI Evaluation');
+          await api.initializeEvaluationSession();
           
           setEvaluationProgress(10);
           let agentId = currentAgentId;

--- a/agent-evaluation/src/api/client.ts
+++ b/agent-evaluation/src/api/client.ts
@@ -9,6 +9,7 @@ import { extractResponseText, extractCustomResponseField } from './response.js';
 import {
   setBackendUrl,
   generateApiKey,
+  initializeEvaluationSession,
   createAgent,
   addTestPrompts,
   checkHallucination,
@@ -45,6 +46,7 @@ export const api = {
   extractCustomResponseField,
   callLLMEndpoint,
   generateApiKey,
+  initializeEvaluationSession,
   healthCheck,
   checkKnowledge,
   createAgent,

--- a/agent-evaluation/src/api/evaluation.ts
+++ b/agent-evaluation/src/api/evaluation.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { randomUUID } from 'node:crypto';
 import { logger } from '../utils/logger.js';
 import { callLLMEndpoint } from './llm.js';
 import { type CustomEndpointConfig } from './endpoint.js';
@@ -10,13 +11,19 @@ let client = axios.create({
   },
 });
 
-let API_KEY: string | null = null;
+let SESSION_ID: string | null = null;
+
+function getSessionId() {
+  if (!SESSION_ID) {
+    SESSION_ID = `cli-${randomUUID()}`;
+  }
+
+  return SESSION_ID;
+}
 
 const setupInterceptor = () => {
   client.interceptors.request.use((config) => {
-    if (API_KEY) {
-      config.headers['x-api-key'] = API_KEY;
-    }
+    config.headers['x-session-id'] = getSessionId();
     return config;
   });
 };
@@ -52,24 +59,23 @@ export function setBackendUrl(url: string) {
   logger.debug('Backend URL set to:', url);
 }
 
-export async function generateApiKey(name?: string) {
-  try {
-    const response = await client.post('/api/api-keys/generate-cli', {
-      name: name || 'CLI Evaluation Key'
-    });
-    
-    API_KEY = response.data.apiKey;
-    logger.info('API key generated successfully');
-    logger.debug('API Key:', API_KEY?.substring(0, 12) + '...');
-    
-    const { setApiClient } = await import('./knowledge.js');
-    setApiClient(client, API_KEY);
-    
-    return response.data;
-  } catch (error) {
-    logger.error('Error generating API key:', error);
-    throw error;
-  }
+export async function initializeEvaluationSession() {
+  const sessionId = getSessionId();
+
+  const { setApiClient } = await import('./knowledge.js');
+  setApiClient(client, sessionId);
+
+  logger.info('Evaluation session initialized');
+  logger.debug('Session ID:', `${sessionId.substring(0, 12)}...`);
+
+  return {
+    sessionId,
+    message: 'Evaluation session initialized successfully.',
+  };
+}
+
+export async function generateApiKey(_name?: string) {
+  return initializeEvaluationSession();
 }
 
 export async function createAgent(publicUrl: string, customPayloadTemplate?: string) {
@@ -415,5 +421,4 @@ export async function runAllPromptEvaluations(
   }
   return results;
 }
-
 

--- a/agent-evaluation/src/api/knowledge.ts
+++ b/agent-evaluation/src/api/knowledge.ts
@@ -11,11 +11,11 @@ let client = axios.create({
   },
 });
 
-let API_KEY: string | null = null;
+let SESSION_ID: string | null = null;
 
-export function setApiClient(newClient: any, apiKey: string | null) {
+export function setApiClient(newClient: any, sessionId: string | null) {
   client = newClient;
-  API_KEY = apiKey;
+  SESSION_ID = sessionId;
 }
 
 export async function healthCheck() {
@@ -159,7 +159,7 @@ export async function uploadPdfToAgent(
       `/api/agents/${agentId}/upload-pdf`,
       formData,
       {
-        headers: API_KEY ? { 'x-api-key': API_KEY } : {},
+        headers: SESSION_ID ? { 'x-session-id': SESSION_ID } : {},
         maxBodyLength: Infinity,
         maxContentLength: Infinity,
         timeout: 300000
@@ -218,7 +218,7 @@ export async function runEvaluation(
   onProgress?: (progress: number) => void
 ) {
   const { 
-    generateApiKey, 
+    initializeEvaluationSession,
     createAgent, 
     addTestPrompts, 
     runAllPromptEvaluations 
@@ -228,6 +228,7 @@ export async function runEvaluation(
     const startTime = Date.now();
     
     if (onProgress) onProgress(10);
+    await initializeEvaluationSession();
     const payloadTemplate = config.customConfig?.bodyTemplate || '{"message": "[eval-question]"}';
     const agent = await createAgent(config.agentEndpoint, payloadTemplate);
     const agentId = agent.id;
@@ -308,5 +309,4 @@ export async function runEvaluation(
     throw error;
   }
 }
-
 


### PR DESCRIPTION
Summary

Fixes the Eval CLI connection flow for open-source usage by using a local evaluation session instead of requesting a generated API key.

What changed

- Initializes a local CLI session ID for each evaluation run.
- Sends the session ID as x-session-id on Rippletide API requests.
- Updates CLI progress text and README wording from API-key generation to evaluation sessions.

