### PR TITLE
Docs: point playground at platform backend

### DIFF
--- a/docs/docs/mcp/overview.mdx
+++ b/docs/docs/mcp/overview.mdx
@@ -258,7 +258,7 @@ For this Overview demo, the right side is preloaded with **code best practices**
   </div>
 
   <script>
-    var API_BASE = 'https://playground-proxy-docs.vercel.app';
+    var API_BASE = 'https://agent-evalserver-production.up.railway.app';
     var MCP_AGENT_CHAT_URL = 'https://agent-evalserver-production.up.railway.app/api/agents/51e43552-0cc3-4029-bc81-8e489e3d4235/chat';
     var MCP_AGENT_ID = '51e43552-0cc3-4029-bc81-8e489e3d4235';
     var DEMO_ID = 'overview-live-preloaded';

--- a/docs/docs/mcp/try-it-yourself.mdx
+++ b/docs/docs/mcp/try-it-yourself.mdx
@@ -218,7 +218,7 @@ Try teaching the agent on the right project facts, then ask it to recall them.
   </div>
 
   <script>
-    var API_BASE = 'https://playground-proxy-docs.vercel.app';
+    var API_BASE = 'https://agent-evalserver-production.up.railway.app';
     var DEMO_ID = 'try-it-yourself-live';
     var DEMO_MODE = 'empty';
     var PRELOADED_MEMORIES = [];


### PR DESCRIPTION
## Summary
- Point the MCP docs playground iframes at the platform backend instead of the deleted Vercel proxy.
- Updates both the overview demo and try-it-yourself demo.

## Verification
- Confirmed the MDX diff only changes API_BASE.

## Notes
- Depends on the matching rippletide-platform backend PR being deployed before or with this docs change.