### PR TITLE
docs: reframe Connect Agent as CLI hub

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -38,9 +38,10 @@
             ]
           },
           {
-            "group": "Connect Agent",
+            "group": "CLI",
             "expanded": true,
             "pages": [
+              "docs/cli",
               "docs/connect-agent"
             ]
           },
@@ -78,6 +79,7 @@
                 "expanded": false,
                 "pages": [
                   "docs/trust-platform/overview",
+                  "docs/cli",
                   "docs/connect-agent"
                 ]
               },

--- a/docs/docs/cli.mdx
+++ b/docs/docs/cli.mdx
@@ -1,0 +1,295 @@
+---
+title: Rippletide CLI
+description: Install, auth, connect, home, rules, clear, and day-2 commands for rippletide-package
+---
+
+The Rippletide CLI connects an existing TypeScript/JavaScript agent repo to Rippletide Cloud, then gives you an interactive home for tools, rules, diagnostics, and evaluation.
+
+Published package: [`rippletide-package`](https://www.npmjs.com/package/rippletide-package)
+(bins: `rippletide`, `rippletide-package`).
+
+<Warning>
+  Install **`rippletide-package`**, not the unscoped npm package `rippletide`
+  (legacy Evaluation CLI — wrong product).
+
+  Prefer `npm install -g rippletide-package` or
+  `npx -p rippletide-package rippletide …`.
+  Do **not** run `npx rippletide` / `npm install -g rippletide` for this path.
+
+  For **Rippletide Code** (coding-rules hooks via `npx rippletide-code`), see
+  [Coding Agents → Connect](/docs/coding-agents/connect).
+</Warning>
+
+## Happy path
+
+```bash
+npm install -g rippletide-package
+
+rippletide login
+cd <your-agent-repo>
+rippletide connect
+# Success = heartbeat seen → Tools + rules menu
+
+rippletide                 # Interactive home (dashboard when connected)
+rippletide clear           # Remove Rippletide from this repo
+```
+
+**Connect success = heartbeat.** A separate proof turn is **not** required for MVP.
+
+Short coding-agent prompt that should be enough:
+
+```text
+Use Rippletide to connect this agent.
+```
+
+See also the shorter [Connect an existing agent](/docs/connect-agent) path.
+
+---
+
+## Install
+
+**Published**
+
+```bash
+npm install -g rippletide-package
+rippletide <command>
+
+# one-off without a global install:
+npx -p rippletide-package rippletide <command>
+# or:
+npx rippletide-package <command>
+```
+
+**Local QA** (unpublished checkout of the platform monorepo):
+
+```bash
+node path/to/rippletide-package/bin/rippletide.js <command>
+```
+
+---
+
+## Auth
+
+```bash
+rippletide login
+# Local API:
+rippletide login --endpoint http://localhost:3001
+# Platform UI “Connect Agent” flow (auto-authorize when already signed in):
+rippletide login --platform
+```
+
+| Command | Purpose |
+| --- | --- |
+| `login [--endpoint <url>] [--platform]` | Browser device-flow login → `~/.rippletide/config.json` |
+| `whoami` | Show the logged-in account |
+| `logout` | Clear local account credentials |
+| `agents` | List account agents |
+| `agents <query>` / `agent <query>` | Show one agent (id, short id, or name) |
+
+- **Humans:** run `rippletide login` (browser opens).
+- **Agents / CI:** `rippletide login --json` prints `verification_uri_complete` / `user_code` (no auto-open); complete Auth0, then wait until `status=ok`.
+- Default API is **production**. Pass `--endpoint` only when you intentionally want local or staging.
+
+---
+
+## Connect
+
+Run from the agent repo:
+
+```bash
+rippletide connect
+```
+
+What happens:
+
+1. Creates or links an agent; writes `.rippletide/project.json` + `.env` (`RIPPLETIDE`, `RIPPLETIDE_PROXY_URL`)
+2. Guides coding-agent setup (Cursor / Claude Code / Codex / …) or lets you paste the setup prompt
+3. Waits for a **heartbeat** — that is connect success
+4. Opens the **Tools + rules** browser
+
+Safe to re-run to refresh credentials or retest.
+
+| Flag | When to use |
+| --- | --- |
+| `--yes` | Non-interactive: run declared `rippletide:sync` / `rippletide:start` without prompts |
+| `--agent <id>` | Bind this repo to an existing agent |
+| `--json` | Machine-readable output (agents / CI) |
+| `--wait-evidence` | Optional: also wait for full runtime evidence (heartbeat + turn). **Not required** for MVP connect |
+
+Alternate path from the platform UI (**Connect Agent**):
+
+```bash
+npx rippletide-package@latest login --platform
+npx rippletide-package@latest connect
+```
+
+### Prerequisites
+
+- A TypeScript/JavaScript agent repo the coding agent can edit
+- Customer secrets the agent already needs (model key, HubSpot token, …) in the
+  environment — Rippletide does not invent or commit those
+- Computer use / controlled browser for Auth0 device login (or a human once)
+
+### If scripts are missing
+
+Compatible repos declare:
+
+- `rippletide:sync` — register identity, prompts, tools (inventory)
+- `rippletide:start` (optional but recommended) — keep the Runtime worker online
+
+`rippletide connect` does **not** rewrite arbitrary application code. Interactive
+connect offers a coding-agent setup prompt. For unknown layouts, the coding agent
+adds thin SDK wiring, then re-runs `connect` until a heartbeat appears.
+
+---
+
+## Home / dashboard
+
+```bash
+rippletide
+# same as:
+rippletide home
+```
+
+Interactive home covers agent overview, runtime evidence, tools/rules, evaluate, and clear.
+
+Off-TTY or `--json`: prints next-step text only (no hang).
+
+---
+
+## Tools and policy rules
+
+After connect (heartbeat), open the tools + rules browser:
+
+```bash
+rippletide create-rules
+# alias: rippletide generate-rules
+```
+
+Or compile and save one rule non-interactively:
+
+```bash
+rippletide create-rules \
+  --agent <agentId> \
+  --action calendar/create_event \
+  --input "Only admins may invite external attendees." \
+  [--context "…"] [--out rules.json] [--enable]
+```
+
+### `rules` subcommands
+
+Same backend as the Rules UI (`/api/policy-targets/.../rules`). Prefer `--agent` or a connected repo; `--target` is advanced.
+
+| Command | Purpose |
+| --- | --- |
+| `rules targets` | List policy targets (`rules agents` is an alias) |
+| `rules show-target <targetId>` | Show one target and its action catalogue |
+| `rules create-target --agent <id>` | Create/sync a target from an agent catalogue |
+| `rules create-target --name <name> --catalog <file>` | Create from a JSON catalogue file |
+| `rules list [--agent <id>]` | List rule releases |
+| `rules compile --action <key> --input "…"` | Compile NL → RuleV1 + fingerprint |
+| `rules save --file <path>` | Save a compiled release (starts disabled) |
+| `rules enable --release <id>` | Enable a release |
+| `rules disable --release <id>` | Disable a release |
+| `rules control-mode --mode observe\|enforce` | Set target control mode |
+
+```bash
+rippletide rules list --agent <agentId>
+rippletide rules control-mode --agent <agentId> --mode observe
+```
+
+New catalogues start in **observe**. Switch to `enforce` only after you trust observe-mode decisions.
+
+---
+
+## Clear / disconnect
+
+```bash
+rippletide clear
+# alias: rippletide disconnect
+```
+
+Removes Rippletide from the repo: coding-agent source cleanup, local artifacts, package dep, gitignore `.env` line, and the platform agent (when logged in).
+
+| Flag | Purpose |
+| --- | --- |
+| `--yes --agent <codex\|claude\|cursor\|…>` | Skip confirmation; `--agent` is required with `--yes` |
+| `--keep-agent` | Do not delete the platform agent via API |
+| `--auth` | Also clear CLI login (`~/.rippletide/config.json`) |
+| `--json` | Machine-readable output |
+
+Also available: `rippletide verify` — prove the repo connection from `./.env` and read back synced inventory.
+
+---
+
+## Day-2 commands
+
+Use these after connect when you need them — not part of the MVP finish line.
+
+| Command | Purpose |
+| --- | --- |
+| `status` | Account + project readiness snapshot |
+| `doctor` | Diagnose auth / project / env / inventory / runner / evidence gaps |
+| `events [--limit <n>] [--wait]` | List ingest events; `--wait` until heartbeat + turn |
+| `evaluate [--generate] [--wait] [--details]` | Start connected-agent evaluation |
+| `improve [--wait] [--yes] …` | Improvement loop (confirm before start; agents may use `--yes`) |
+
+```bash
+rippletide status
+rippletide doctor
+rippletide events --limit 20
+rippletide evaluate --generate --wait
+rippletide improve --wait
+```
+
+`improve` also accepts `--zone` / `--criterion`, `--refresh-zones`, `--scenarios`, `--max-iterations`, and `--target-score`.
+
+---
+
+## Global flags and tips
+
+| Flag / tip | Notes |
+| --- | --- |
+| `--json` | Machine-readable output on every command (global or per-command) |
+| `--endpoint <url>` | On `login` (and accepted but ignored on `logout`) for local/staging API |
+| `--yes` | Non-interactive confirm on `connect`, `clear`, `improve` |
+| `rippletide help <command>` | Flags for a single command |
+| Local QA bin | `node path/to/rippletide-package/bin/rippletide.js` |
+
+---
+
+## Local files
+
+| Scope | Path | Contents |
+| --- | --- | --- |
+| Account | `~/.rippletide/config.json` (mode `0600`) | endpoint + account API key |
+| Project | `.rippletide/project.json` | `agentId`, `agentName` (commit-friendly) |
+| SDK env | `.env` | `RIPPLETIDE` + `RIPPLETIDE_PROXY_URL` (do not commit) |
+
+---
+
+## For coding agents
+
+| Goal | Command |
+| --- | --- |
+| Log in (human) | `rippletide login` |
+| Log in (agent / CI) | `rippletide login --json` → open `verification_uri_complete` → wait for `status=ok` |
+| Connect | `rippletide connect` (TTY) or `rippletide connect --yes` |
+| Local / staging API | `rippletide login --endpoint <url>` then connect |
+| Success | Heartbeat seen → Tools + rules |
+| Home / dashboard | `rippletide` or `rippletide home` |
+| Tear down | `rippletide clear` (`--yes` requires `--agent <codex\|claude\|cursor\|…>`) |
+
+Do **not** require a proof turn to mark connect done. Do **not** invent or commit customer secrets.
+
+| Prompt | Expected behavior |
+| --- | --- |
+| `Use Rippletide to connect this agent` | login → connect → heartbeat → tools |
+| `Create a policy rule for this action` | `create-rules` → `rules list` |
+
+---
+
+## Package reference
+
+Full CLI and SDK reference:
+[npmjs.com/package/rippletide-package](https://www.npmjs.com/package/rippletide-package)

--- a/docs/docs/connect-agent.mdx
+++ b/docs/docs/connect-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: Connect an existing agent
-description: Tell Codex or Cursor “Use Rippletide to connect this agent” — login, connect (heartbeat), tools
+description: Short path — login, connect (heartbeat), tools. Full command reference lives in CLI.
 ---
 
 User ask that should be enough:
@@ -15,21 +15,20 @@ Or:
 Install Rippletide on this agent and connect it end-to-end.
 ```
 
-The coding agent should find this page (or the
-[`rippletide-package` npm README](https://www.npmjs.com/package/rippletide-package))
-and run the loop below. No long pasted prompt is required.
+The coding agent should follow this page or the full
+[Rippletide CLI](/docs/cli) guide
+([`rippletide-package` on npm](https://www.npmjs.com/package/rippletide-package)).
 
 <Warning>
-  This is the **Connect Agent / `rippletide-package` CLI** path for an existing
-  TypeScript or JavaScript agent repo.
+  Install **`rippletide-package`**, not the unscoped npm package `rippletide`
+  (legacy Evaluation CLI — wrong product for connect).
 
-  - Install **`rippletide-package`**, not the unscoped npm package `rippletide`
-    (legacy Evaluation CLI — wrong product for connect).
-  - Prefer `npx -p rippletide-package rippletide …` or
-    `npm install -g rippletide-package`. Do **not** run `npx rippletide` /
-    `npm install -g rippletide` for this path.
-  - For **Rippletide Code** (coding rules hooks in Claude Code via
-    `npx rippletide-code`), see [Coding Agents → Connect](/docs/coding-agents/connect).
+  Prefer `npx -p rippletide-package rippletide …` or
+  `npm install -g rippletide-package`.
+
+  Full command reference: [Rippletide CLI](/docs/cli).
+  For **Rippletide Code** (`npx rippletide-code`), see
+  [Coding Agents → Connect](/docs/coding-agents/connect).
 </Warning>
 
 ## Quickstart
@@ -45,22 +44,12 @@ rippletide connect
 **Success = heartbeat seen.** Connect then opens the Tools + rules menu.
 A separate proof turn is **not** required to finish connect.
 
-Open the home / dashboard menu anytime:
-
 ```bash
-rippletide
-# same as: rippletide home
-```
-
-Remove Rippletide from the repo:
-
-```bash
-rippletide clear
+rippletide                 # home / dashboard
+rippletide clear           # remove Rippletide from this repo
 ```
 
 ## What “connected” means
-
-For MVP connect:
 
 1. Repo is bound (credentials + `.env` written)
 2. Rippletide sees a **heartbeat** from the agent
@@ -68,135 +57,20 @@ For MVP connect:
 That unlocks Tools + rules. Inventory sync and evaluation can follow later —
 they are not the connect finish line.
 
-A copied command or a “setup complete” screen alone is not enough without a heartbeat.
-
-## Prerequisites
-
-- A TypeScript/JavaScript agent repo the coding agent can edit
-- Customer secrets the agent already needs (model key, HubSpot token, …) in the
-  environment — Rippletide does not invent or commit those
-- Computer use / controlled browser for Auth0 device login (or a human once)
-
-Default API is **production**. Do not pass a staging `--endpoint` unless you
-intentionally want staging.
-
-## Install
-
-**Published**
-
-```bash
-npm install -g rippletide-package
-# then:
-rippletide <command>
-
-# one-off (recommended form — package name is explicit):
-npx -p rippletide-package rippletide <command>
-# or:
-npx rippletide-package <command>
-```
-
-**Local QA** (developing against an unpublished checkout):
-
-```bash
-node path/to/rippletide-package/bin/rippletide.js <command>
-```
-
-## Steps
-
-```bash
-# 1) Account login (device flow). Opens the browser; complete Auth0 if needed.
-rippletide login
-
-# 2) Bind this repo. Interactive connect runs coding-agent setup and waits
-#    for a heartbeat, then opens Tools + rules.
-cd <agent-repo>
-rippletide connect
-
-# Non-interactive (CI / agents): run declared sync/start scripts without prompts
-# rippletide connect --yes
-```
-
-Humans should run `rippletide login` (browser opens). Use `rippletide login --json`
-only for coding-agent / CI automation: it prints a pending JSON line with
-`verification_uri_complete` and does **not** open the browser.
-
-Alternate path from the platform UI: open **Connect Agent**, then:
-
-```bash
-npx rippletide-package@latest login --platform
-npx rippletide-package@latest connect
-```
-
-## For coding agents
+## Coding-agent cheat sheet
 
 | Goal | Command |
 | --- | --- |
 | Log in (human) | `rippletide login` |
 | Log in (agent / CI) | `rippletide login --json` → open `verification_uri_complete` → wait for `status=ok` |
-| Connect | `rippletide connect` (TTY) or `rippletide connect --yes` |
-| Local / staging API | `rippletide login --endpoint <url>` then connect |
-| Success | Heartbeat seen → Tools + rules |
-| Home / dashboard | `rippletide` or `rippletide home` |
-| Tear down | `rippletide clear` (`--yes` requires `--agent <codex\|claude\|cursor\|…>`) |
+| Connect | `rippletide connect` or `rippletide connect --yes` |
+| Success | Heartbeat → Tools + rules |
+| Tear down | `rippletide clear` |
 
-Do **not** require a proof turn to mark connect done. Do **not** invent or commit customer secrets.
+Platform UI path: **Connect Agent** →
+`npx rippletide-package@latest login --platform` then `connect`.
 
-## CLI surface (happy path first)
+## Next
 
-| Command | Purpose |
-| --- | --- |
-| `login [--endpoint] [--platform]` | Device-flow login (`~/.rippletide`) |
-| `connect [--yes] [--agent <id>]` | Bind repo; wait for heartbeat; open tools |
-| *(no args)* / `home` | Interactive home / dashboard |
-| `clear` | Remove Rippletide from this repo |
-| `whoami` / `logout` / `agents` | Account helpers |
-| `status` / `doctor` / `events` | Day-2 readiness / diagnostics |
-| `create-rules` | Tools + rules browser, or compile one rule |
-| `evaluate` / `improve` | Day-2 evaluation and improvement loops |
-
-All commands accept `--json` for machine-readable output (agents / CI).
-
-## Policy rules (optional)
-
-After connect, author platform policy rules (same backend as the Rules UI /
-`/api/policy-targets/.../rules`). Prefer `--agent` or a connected repo.
-
-```bash
-rippletide create-rules
-# or:
-rippletide create-rules \
-  --agent <agentId> \
-  --action calendar/create_event \
-  --input "Only admins may invite external attendees."
-rippletide rules list --agent <agentId>
-rippletide rules control-mode --agent <agentId> --mode observe
-```
-
-New catalogues start in **observe**. Switch to `enforce` only after you trust observe-mode decisions.
-
-## If scripts are missing
-
-Compatible repos declare:
-
-- `rippletide:sync` — register identity, prompts, tools (inventory)
-- `rippletide:start` (optional but recommended) — keep the Runtime worker online
-
-`rippletide connect` does **not** rewrite arbitrary application code. Interactive
-connect offers a coding-agent setup prompt (auto-run or copy-paste). For unknown
-layouts, the coding agent adds thin SDK wiring, then re-runs `connect` until a
-heartbeat appears.
-
-## One-line prompts
-
-| Prompt | Expected behavior |
-| --- | --- |
-| `Use Rippletide to connect this agent` | login → connect → heartbeat → tools |
-| `Create a policy rule for this action` | `create-rules` → `rules list` |
-
-If a cold coding agent fails the short prompt, the fix is better public docs /
-npm discoverability — not a longer prompt for every user.
-
-## Package reference
-
-Full CLI and SDK reference:
-[npmjs.com/package/rippletide-package](https://www.npmjs.com/package/rippletide-package)
+- Full CLI: install, auth, home, rules, clear, day-2 → [Rippletide CLI](/docs/cli)
+- npm README: [rippletide-package](https://www.npmjs.com/package/rippletide-package)

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -14,13 +14,22 @@ Already have an agent in a repo? Tell Codex/Cursor:
 Use Rippletide to connect this agent.
 ```
 
-Then follow [Connect an existing agent](/docs/connect-agent)
+Then follow the [Rippletide CLI](/docs/cli)
 (`rippletide-package`: login → connect → heartbeat → tools).
+Short path: [Connect an existing agent](/docs/connect-agent).
 Do **not** install the unscoped npm package `rippletide` (legacy Eval CLI).
 <h3 className="toc-only">Bring the right context (Context Graph)</h3>
 <h3 className="toc-only">Make your agent deterministic (Decision runtime)</h3>
 
 <Steps>
+  <Step title="CLI: Connect an existing agent">
+    Install `rippletide-package`, log in, connect the repo, and land on Tools when a heartbeat is seen.
+
+    **When to use it:** You already run a TypeScript/JavaScript agent and want Rippletide evidence + policy without rebuilding it.
+
+    [Rippletide CLI →](/docs/cli)
+  </Step>
+
   <Step title="Context Graph: Bring the right context for a more predictable agent">
     A persistent context graph that stores facts, decisions, preferences, and entity relationships across conversations. Your agents remember what matters without re-prompting.
 
@@ -51,9 +60,13 @@ Rippletide demonstrated strong measured performance on a range of use cases: cus
 
 ## What's Next?
 
-Explore the two core areas of Rippletide:
+Explore Rippletide:
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
+  <Card title="CLI" icon="terminal" href="/docs/cli">
+    Connect an existing agent with rippletide-package
+  </Card>
+
   <Card title="Context Graph" icon="diagram-project" href="/docs/mcp/overview">
     Always bring the right context to your agent to make it more predictable
   </Card>


### PR DESCRIPTION
## Summary
- Add primary **CLI** doc (`docs/docs/cli.mdx`) covering install → auth → connect → home/tools/rules → clear → day-2 commands for `rippletide-package`
- Rename Mintlify nav group from "Connect Agent" to **CLI**; keep `connect-agent` as a short happy-path page that links into the CLI hub
- Update welcome page to surface CLI alongside Context Graph / Decision runtime
- Warn: use `rippletide-package`, not unscoped `rippletide`; heartbeat = connect success (no proof-turn)

## Test plan
- [ ] Mintlify preview / CI green
- [ ] Sidebar shows **CLI** with `Rippletide CLI` then `Connect an existing agent`
- [ ] `/docs/cli` covers login, connect, home, clear, status/doctor/events, create-rules, rules.*, evaluate, improve, `--yes` / `--endpoint` / `--json`
- [ ] `/docs/connect-agent` remains a short path and links to `/docs/cli`
- [ ] Index quick start points at CLI first


Made with [Cursor](https://cursor.com)